### PR TITLE
golang build time version check; update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 cmd/netwrangler
+.DS_Store

--- a/run.go
+++ b/run.go
@@ -14,6 +14,8 @@ import (
 	"github.com/rackn/netwrangler/util"
 )
 
+var _ = ___NETWRANGLER_REQUIRES_GO_VERSION_1_12_OR_HIGHER_TO_BUILD___
+
 var (
 	// The input formats we accept.  internal is the intermediate format netwrangler uses.
 	SrcFormats = []string{"netplan", "internal"}

--- a/version_check.go
+++ b/version_check.go
@@ -1,0 +1,6 @@
+// +build go1.12
+
+package netwrangler
+
+// require Golang 1.12 or higher to build (eg strings.ReplaceAll)
+const ___NETWRANGLER_REQUIRES_GO_VERSION_1_12_OR_HIGHER_TO_BUILD___ = true


### PR DESCRIPTION
- `strings.ReplaceAll()` introduces build dependency requirement on golang 1.12
- add `version_check.go` with build tag (1.12) and `const` for better error message
- add `run.go` support to fail if build tag doesn't succeed
- add stupid Mac OSX guano to `.gitignore`

Version checking was successfully tested on my Mac which originally was golang version 1.10.1 - which failed to build properly.  Adding check, updating golang to version 1.12.2 and trying to build again succeeded.