### PR TITLE
Add Netplan as a valid output target as well.

### DIFF
--- a/run.go
+++ b/run.go
@@ -18,7 +18,7 @@ var (
 	// The input formats we accept.  internal is the intermediate format netwrangler uses.
 	SrcFormats = []string{"netplan", "internal"}
 	// The output formats we can handle.  internal is the intermediate format netwrangler uses.
-	DestFormats = []string{"systemd", "rhel", "internal"}
+	DestFormats = []string{"netplan", "systemd", "rhel", "internal"}
 	// The MAC address of the device we booted from.
 	bootMac net.HardwareAddr
 )
@@ -62,6 +62,8 @@ func Write(layout *util.Layout, destFmt, destLoc string, bindMacs bool) error {
 	switch destFmt {
 	case "internal":
 		out = layout
+	case "netplan":
+		out = netplan.New(layout)
 	case "systemd":
 		out = systemd.New(layout)
 	case "rhel":

--- a/run_test.go
+++ b/run_test.go
@@ -197,7 +197,7 @@ func testRun(t *testing.T, loc, in, out string, wantErr bool) {
 func rt(t *testing.T, loc string, wantErr bool) {
 	t.Helper()
 	for _, in := range []string{"netplan"} {
-		for _, out := range []string{"internal", "systemd", "rhel"} {
+		for _, out := range DestFormats {
 			testRun(t, loc, in, out, wantErr)
 		}
 	}

--- a/test-data/bonding/netplan/expect
+++ b/test-data/bonding/netplan/expect
@@ -1,0 +1,13 @@
+network:
+  bonds:
+    bond0:
+      accept-ra: true
+      dhcp4: true
+      interfaces:
+      - enp3s0
+      - enp4s0
+      parameters:
+        mode: active-backup
+        primary: enp3s0
+  renderer: networkd
+  version: 2

--- a/test-data/bonding_router/netplan/expect
+++ b/test-data/bonding_router/netplan/expect
@@ -1,0 +1,51 @@
+network:
+  bonds:
+    bond-conntrack:
+      accept-ra: true
+      addresses:
+      - 192.168.254.2/24
+      interfaces:
+      - enp5s0
+      - enp6s0
+      parameters:
+        mii-monitor-interval: 1
+        mode: balance-rr
+    bond-lan:
+      accept-ra: true
+      addresses:
+      - 192.168.93.2/24
+      interfaces:
+      - enp2s0
+      - enp3s0
+      parameters:
+        mii-monitor-interval: 1
+        mode: 802.3ad
+    bond-wan:
+      accept-ra: true
+      addresses:
+      - 192.168.1.252/24
+      gateway4: 192.168.1.1
+      interfaces:
+      - enp1s0
+      - enp4s0
+      nameservers:
+        addresses:
+        - 8.8.8.8
+        - 8.8.4.4
+        search:
+        - local
+      parameters:
+        gratuitous-arp: 5
+        mii-monitor-interval: 1
+        mode: active-backup
+  ethernets:
+    enp3s0:
+      optional: true
+    enp4s0:
+      optional: true
+    enp5s0:
+      optional: true
+    enp6s0:
+      optional: true
+  renderer: networkd
+  version: 2

--- a/test-data/bridge/netplan/expect
+++ b/test-data/bridge/netplan/expect
@@ -1,0 +1,9 @@
+network:
+  bridges:
+    br0:
+      accept-ra: true
+      dhcp4: true
+      interfaces:
+      - enp3s0
+  renderer: networkd
+  version: 2

--- a/test-data/bridge_vlan/netplan/expect
+++ b/test-data/bridge_vlan/netplan/expect
@@ -1,0 +1,18 @@
+network:
+  bridges:
+    br0:
+      accept-ra: true
+      addresses:
+      - 10.3.99.25/24
+      interfaces:
+      - vlan15
+  ethernets:
+    enp0s25:
+      accept-ra: true
+      dhcp4: true
+  renderer: networkd
+  version: 2
+  vlans:
+    vlan15:
+      id: 15
+      link: enp0s25

--- a/test-data/bridge_vlan_ordinal/netplan/expect
+++ b/test-data/bridge_vlan_ordinal/netplan/expect
@@ -1,0 +1,27 @@
+network:
+  bridges:
+    br0:
+      accept-ra: true
+      addresses:
+      - 10.3.99.25/24
+      interfaces:
+      - enp3s0
+      - enp4s0
+      - enp5s0
+      - enp6s0
+  ethernets:
+    eno1:
+      accept-ra: true
+      dhcp4: true
+    ens3:
+      accept-ra: true
+      dhcp4: true
+    ens5:
+      accept-ra: true
+      dhcp4: true
+  renderer: networkd
+  version: 2
+  vlans:
+    vlan15:
+      id: 15
+      link: br0

--- a/test-data/dhcp-bindMacs/netplan/expect
+++ b/test-data/dhcp-bindMacs/netplan/expect
@@ -1,0 +1,9 @@
+network:
+  ethernets:
+    enp3s0:
+      accept-ra: true
+      dhcp4: true
+      match:
+        macaddress: "52:54:01:23:00:03"
+  renderer: networkd
+  version: 2

--- a/test-data/dhcp-bootif/netplan/expect
+++ b/test-data/dhcp-bootif/netplan/expect
@@ -1,0 +1,7 @@
+network:
+  ethernets:
+    eno1:
+      accept-ra: true
+      dhcp4: true
+  renderer: networkd
+  version: 2

--- a/test-data/dhcp/netplan/expect
+++ b/test-data/dhcp/netplan/expect
@@ -1,0 +1,7 @@
+network:
+  ethernets:
+    enp3s0:
+      accept-ra: true
+      dhcp4: true
+  renderer: networkd
+  version: 2

--- a/test-data/direct_connect_gateway/netplan/expectErr
+++ b/test-data/direct_connect_gateway/netplan/expectErr
@@ -1,0 +1,6 @@
+Error reading 'netplan': netplan:
+cannot validate format []interface {}
+[]interface {} not castable to an ethernet interface
+cannot validate format []interface {}
+[]interface {} not castable to an ethernet interface
+

--- a/test-data/loopback_interface/netplan/expectErr
+++ b/test-data/loopback_interface/netplan/expectErr
@@ -1,0 +1,3 @@
+Error reading 'netplan': netplan:
+Ethernet interface lo does not resolve to any interfaces
+

--- a/test-data/source_routing/netplan/expect
+++ b/test-data/source_routing/netplan/expect
@@ -1,0 +1,29 @@
+network:
+  ethernets:
+    ens3:
+      accept-ra: true
+      addresses:
+      - 192.168.3.30/24
+      routes:
+      - table: 101
+        to: 192.168.3.0/24
+        type: unicast
+        via: 192.168.3.1
+      routing-policy:
+      - from: 192.168.3.0/24
+        table: 101
+    ens5:
+      accept-ra: true
+      addresses:
+      - 192.168.5.24/24
+      gateway4: 192.168.5.1
+      routes:
+      - table: 102
+        to: 192.168.5.0/24
+        type: unicast
+        via: 192.168.5.1
+      routing-policy:
+      - from: 192.168.5.0/24
+        table: 102
+  renderer: networkd
+  version: 2

--- a/test-data/static/netplan/expect
+++ b/test-data/static/netplan/expect
@@ -1,0 +1,16 @@
+network:
+  ethernets:
+    enp3s0:
+      accept-ra: true
+      addresses:
+      - 10.10.10.2/24
+      gateway4: 10.10.10.1
+      nameservers:
+        addresses:
+        - 10.10.10.1
+        - 1.1.1.1
+        search:
+        - mydomain
+        - otherdomain
+  renderer: networkd
+  version: 2

--- a/test-data/static_multiaddress/netplan/expect
+++ b/test-data/static_multiaddress/netplan/expect
@@ -1,0 +1,10 @@
+network:
+  ethernets:
+    enp3s0:
+      accept-ra: true
+      addresses:
+      - 10.100.1.38/24
+      - 10.100.1.39/24
+      gateway4: 10.100.1.1
+  renderer: networkd
+  version: 2

--- a/test-data/static_singlenic_multiip_multigateway/netplan/expect
+++ b/test-data/static_singlenic_multiip_multigateway/netplan/expect
@@ -1,0 +1,22 @@
+network:
+  ethernets:
+    eno1:
+      accept-ra: true
+      addresses:
+      - 10.0.0.10/24
+      - 11.0.0.11/24
+      nameservers:
+        addresses:
+        - 8.8.8.8
+        - 8.8.4.4
+      routes:
+      - metric: 100
+        to: 0.0.0.0/0
+        type: unicast
+        via: 10.0.0.1
+      - metric: 100
+        to: 0.0.0.0/0
+        type: unicast
+        via: 11.0.0.1
+  renderer: networkd
+  version: 2

--- a/test-data/vlan/netplan/expect
+++ b/test-data/vlan/netplan/expect
@@ -1,0 +1,34 @@
+network:
+  ethernets:
+    enp9s5:
+      accept-ra: true
+      addresses:
+      - 10.3.0.5/23
+      gateway4: 10.3.0.1
+      nameservers:
+        addresses:
+        - 8.8.8.8
+        - 8.8.4.4
+        search:
+        - example.com
+  renderer: networkd
+  version: 2
+  vlans:
+    vlan10:
+      accept-ra: true
+      addresses:
+      - 10.3.98.5/24
+      id: 10
+      link: enp9s5
+      nameservers:
+        addresses:
+        - 127.0.0.1
+        search:
+        - domain1.example.com
+        - domain2.example.com
+    vlan15:
+      accept-ra: true
+      addresses:
+      - 10.3.99.5/24
+      id: 15
+      link: enp9s5

--- a/test-data/windows_dhcp_server/netplan/expect
+++ b/test-data/windows_dhcp_server/netplan/expect
@@ -1,0 +1,8 @@
+network:
+  ethernets:
+    enp3s0:
+      accept-ra: true
+      dhcp-identifier: mac
+      dhcp4: true
+  renderer: networkd
+  version: 2

--- a/test-data/wireless/netplan/expectErr
+++ b/test-data/wireless/netplan/expectErr
@@ -1,0 +1,3 @@
+Error reading 'netplan': netplan:
+Wifi interfaces not supported
+

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 set -e
+# Work out the GO version we are working with:
+GO_VERSION=$(go version | awk '{ print $3 }' | sed 's/go//')
+WANTED_VER=(1 12)
+if ! [[ "$GO_VERSION" =~ ([0-9]+)\.([0-9]+) ]]; then
+    echo "Cannot figure out what version of Go is installed"
+    exit 1
+elif ! (( ${BASH_REMATCH[1]} > ${WANTED_VER[0]} || ${BASH_REMATCH[2]} >= ${WANTED_VER[1]} )); then
+    echo "Go Version needs to be ${WANTED_VER[0]}.${WANTED_VER[1]} or higher: currently $GO_VERSION"
+    exit -1
+fi
 [[ $GOPATH ]] || export GOPATH="$HOME/go"
 fgrep -q "$GOPATH/bin" <<< "$PATH" || export PATH="$PATH:$GOPATH/bin"
 if ! which glide &>/dev/null; then

--- a/util/layout.go
+++ b/util/layout.go
@@ -299,6 +299,7 @@ type Interface struct {
 	// Network contains the layer3 network configuration that should be
 	// applied to this Interface once it is brought up, if any.
 	Network *Network `json:"network,omitempty"`
+	bindMac bool
 }
 
 // NewInterface returns a new Interface with non-nil Interfaces and


### PR DESCRIPTION
This compile netplan into a netplan that exactly targets the current
systems.  All netplan IDs are mapped down to physical interfaces.